### PR TITLE
[MWPW-158448] Added stage domains map

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,6 +44,17 @@ const CONFIG = {
     'en/uk': { ietf: 'en', tk: 'hah7vzn.css' },
     'en/apac': { ietf: 'en', tk: 'hah7vzn.css' },
   },
+  stageDomainsMap: {
+    'blog.stage.adobe.com': {
+      'blog.adobe.com': 'origin',
+    },
+    '--blog--adobecom.hlx.live': {
+      'blog.adobe.com': 'origin',
+    },
+    '--blog--adobecom.hlx.page': {
+      'blog.adobe.com': 'origin',
+    },
+  },
 };
 
 // Milo blocks overridden by the Blog project


### PR DESCRIPTION
This PR adds the stageDomainsMap, enabling the conversion of production URLs to their stage equivalents in the stage environment.
More details about this feature can be found in [this discussion](https://github.com/orgs/adobecom/discussions/2880).

Resolves: [MWPW-158448](https://jira.corp.adobe.com/browse/MWPW-158448)

Test URLs:

Before: https://main--blog--adobecom.hlx.page?martech=off
After: https://mwpw-158448-domains-map--blog--adobecom.hlx.page?martech=off